### PR TITLE
feat: 게시글 검색 최적화를 위한 FULLTEXT 인덱스 추가 및 raw 쿼리 적용

### DIFF
--- a/app/(main)/categories/[id]/page.tsx
+++ b/app/(main)/categories/[id]/page.tsx
@@ -6,13 +6,14 @@ import { notFound } from 'next/navigation';
 
 type Props = {
   params: Promise<{ id: string }>;
-  searchParams: { q?: string };
+  searchParams: Promise<{ q?: string }>;
 };
 
 export default async function CategoryPage({ params, searchParams }: Props) {
   const awaitedParams = await params;
+  const awaitedSearchParams = await searchParams;
   const categoryId = Number.parseInt(awaitedParams.id);
-  const searchQuery = searchParams.q || '';
+  const searchQuery = awaitedSearchParams.q?.trim() || '';
 
   if (isNaN(categoryId)) {
     notFound();

--- a/app/(main)/categories/page.tsx
+++ b/app/(main)/categories/page.tsx
@@ -2,11 +2,12 @@ import { CategoryLayout } from '@/components/category/CategoryLayout';
 import { getLatestPosts, searchPosts } from '@/data/post';
 
 type Props = {
-  searchParams: { q?: string };
+  searchParams: Promise<{ q?: string }>;
 };
 
 export default async function CategoriesPage({ searchParams }: Props) {
-  const searchQuery = searchParams.q || '';
+  const awaitedSearchParams = await searchParams;
+  const searchQuery = awaitedSearchParams.q?.trim() || '';
 
   // 검색어가 있으면 검색 함수 사용, 없으면 전체 게시글 가져오기
   const posts = searchQuery

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -2,12 +2,13 @@ import { UserSearchForm } from '@/components/admin/UserSearchForm';
 import { UserTable } from '@/components/admin/UserTable';
 import { getAllUsersWithoutSelf, searchUsersWithoutSelf } from '@/data/user';
 
-export default async function UsersPage({
-  searchParams,
-}: {
-  searchParams: { q?: string };
-}) {
-  const query = searchParams.q?.trim() || '';
+type Props = {
+  searchParams: Promise<{ q?: string }>;
+};
+
+export default async function UsersPage({ searchParams }: Props) {
+  const awaitedSearchParams = await searchParams;
+  const query = awaitedSearchParams.q?.trim() || '';
   const users = query
     ? await searchUsersWithoutSelf(query)
     : await getAllUsersWithoutSelf();

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -36,6 +36,11 @@ const buttonVariants = cva(
   }
 );
 
+export type ButtonProps = React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  };
+
 function Button({
   className,
   variant,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,13 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  {
+    ignores: [
+      'app/generated/**/*', // Prisma 생성 파일 제외
+      '.next/**/*', // Next.js 빌드 파일 제외
+      'node_modules/**/*', // node_modules 제외
+    ],
+  },
 ];
 
 export default eslintConfig;

--- a/prisma/migrations/20250603103406_add_fulltext_index/migration.sql
+++ b/prisma/migrations/20250603103406_add_fulltext_index/migration.sql
@@ -106,3 +106,6 @@ ALTER TABLE `board_reaction` ADD CONSTRAINT `board_reaction_user_id_fkey` FOREIG
 
 -- AddForeignKey
 ALTER TABLE `board_reaction` ADD CONSTRAINT `board_reaction_board_id_fkey` FOREIGN KEY (`board_id`) REFERENCES `Board`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE Board
+ADD FULLTEXT INDEX idx_fulltext_title_content (title, content);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,7 +79,7 @@ model Board {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  // @@index([title, content]) // 검색용
+  // @@index([title, content]) // FULLTEXT INDEX를 통해 검색하기 위해 주석처리
 }
 
 model Image {


### PR DESCRIPTION
## PR 내용 요약
게시글 검색 기능의 성능 및 정확도를 향상시키기 위해 MySQL의 FULLTEXT INDEX를 적용하고, 기존 Prisma DSL 기반 쿼리를 raw query로 리팩토링하였습니다.

## 작업 내역
- `Board` 테이블의 `title`, `content` 컬럼에 **FULLTEXT 인덱스** 추가
    - 마이그레이션 파일에 다음 구문 추가:
        
        ```sql
        ALTER TABLE Board ADD FULLTEXT INDEX idx_fulltext_title_content (title, content);
        ```
        
- 게시글 검색 쿼리를 Prisma의 **`$queryRaw`** 기반으로 변경
    - `MATCH(title, content) AGAINST (... IN NATURAL LANGUAGE MODE)` 문법 사용
    - 검색어 기반 relevance(연관도) 기준으로 결과 정렬
- 기존 Prisma DSL 방식보다 검색 속도 및 유사도 필터링 정확도 향상

## 📎 관련 이슈
- 관련 이슈 번호: #16 